### PR TITLE
Fixes #123 suppress ggplot2 messages when applying scale

### DIFF
--- a/R/plotconfiguration-axis.R
+++ b/R/plotconfiguration-axis.R
@@ -90,12 +90,16 @@ XAxisConfiguration <- R6::R6Class(
     #' @return A \code{ggplot} object with updated axis properties
     setPlotAxis = function(plotObject) {
       if (self$scale %in% "discrete") {
-        plotObject <- plotObject +
-          scale_x_discrete(limits = self$limits, breaks = self$ticks, labels = self$ticklabels)
+        suppressMessages(
+          plotObject <- plotObject +
+            scale_x_discrete(limits = self$limits, breaks = self$ticks, labels = self$ticklabels)
+        )
         return(plotObject)
       }
-      plotObject <- plotObject +
-        scale_x_continuous(trans = self$scale, limits = self$limits, breaks = self$ticks, labels = self$ticklabels)
+      suppressMessages(
+        plotObject <- plotObject +
+          scale_x_continuous(trans = self$scale, limits = self$limits, breaks = self$ticks, labels = self$ticklabels)
+      )
       return(plotObject)
     }
   )
@@ -115,8 +119,10 @@ YAxisConfiguration <- R6::R6Class(
     #' @param plotObject \code{ggplot} object
     #' @return A \code{ggplot} object with updated axis properties
     setPlotAxis = function(plotObject) {
-      plotObject <- plotObject +
-        scale_y_continuous(trans = self$scale, limits = self$limits, breaks = self$ticks, labels = self$ticklabels)
+      suppressMessages(
+        plotObject <- plotObject +
+          scale_y_continuous(trans = self$scale, limits = self$limits, breaks = self$ticks, labels = self$ticklabels)
+      )
       return(plotObject)
     }
   )


### PR DESCRIPTION
suppressMessages does not prevent actual warnings and errors
Consequently, user will still get warning messages if applying log scale to <0 values such as : `NaNs produced`, or `Transformation introduced infinite values in continuous y-axis`