### PR TITLE
Fixes #151 use coord_cartesian

### DIFF
--- a/R/plotconfiguration-axis.R
+++ b/R/plotconfiguration-axis.R
@@ -171,11 +171,15 @@ XAxisConfiguration <- R6::R6Class(
       validateIsOfType(plotObject, "ggplot")
       # Update font properties
       plotObject <- plotObject + ggplot2::theme(axis.text.x = private$.font$createPlotFont())
+      # Update limits using coor_cartesian to prevent ggplot to remove data and crash
+      suppressMessages(
+        plotObject <- plotObject + ggplot2::coord_cartesian(xlim = private$.limits)
+      )
       # Update scales and ticks
       if (isIncluded(private$.scale, Scaling$discrete)) {
         suppressMessages(
           plotObject <- plotObject +
-            ggplot2::scale_x_discrete(limits = private$.limits, breaks = private$.ticks, labels = private$.ticklabels)
+            ggplot2::scale_x_discrete(breaks = private$.ticks, labels = private$.ticklabels)
         )
         return(plotObject)
       }
@@ -183,7 +187,7 @@ XAxisConfiguration <- R6::R6Class(
       # `try` should be added in cases of scale breaking because all the ggplot object elements are not yet in place
       suppressMessages(
         plotObject <- plotObject +
-          ggplot2::scale_x_continuous(trans = private$.scale, limits = private$.limits, breaks = private$.ticks, labels = private$.ticklabels)
+          ggplot2::scale_x_continuous(trans = private$.scale, breaks = private$.ticks, labels = private$.ticklabels)
       )
       return(plotObject)
     }
@@ -207,11 +211,14 @@ YAxisConfiguration <- R6::R6Class(
       validateIsOfType(plotObject, "ggplot")
       # Update font properties
       plotObject <- plotObject + ggplot2::theme(axis.text.y = private$.font$createPlotFont())
+      suppressMessages(
+        plotObject <- plotObject + ggplot2::coord_cartesian(ylim = private$.limits)
+      )
       # Update scales and ticks
       if (isIncluded(private$.scale, Scaling$discrete)) {
         suppressMessages(
           plotObject <- plotObject +
-            ggplot2::scale_y_discrete(limits = private$.limits, breaks = private$.ticks, labels = private$.ticklabels)
+            ggplot2::scale_y_discrete(breaks = private$.ticks, labels = private$.ticklabels)
         )
         return(plotObject)
       }
@@ -219,7 +226,7 @@ YAxisConfiguration <- R6::R6Class(
       # `try` should be added in cases of scale breaking because all the ggplot object elements are not yet in place
       suppressMessages(
         plotObject <- plotObject +
-          ggplot2::scale_y_continuous(trans = private$.scale, limits = private$.limits, breaks = private$.ticks, labels = private$.ticklabels)
+          ggplot2::scale_y_continuous(trans = private$.scale, breaks = private$.ticks, labels = private$.ticklabels)
       )
       return(plotObject)
     }

--- a/R/utilities-background.R
+++ b/R/utilities-background.R
@@ -333,13 +333,16 @@ createWatermarkGrob <- function(label, alpha = NULL) {
     aesthetic = "alpha"
   )
 
+  # Font size is in .pt within annonate and requires a conversion
   watermark <- ggplot2::ggplot() + ggplot2::theme_void() +
     ggplot2::annotate(
       geom = "text",
       x = 0,
       y = 0,
       label = label$text %||% "",
-      color = label$font$color, fontface = label$font$fontFace, size = label$font$size,
+      color = label$font$color, 
+      fontface = label$font$fontFace, 
+      size = label$font$size / ggplot2::.pt,
       angle = label$font$angle, alpha = alpha
     )
   watermark <- ggplot2::ggplotGrob(watermark)


### PR DESCRIPTION
- `coord_trans()` can't be used for the transformation because of the method adding the watermark in background. Consequently, log and discrete transformations still use `scale_x/y_...()`
- For the same reason, `coord_cartesian()` is used to set the axis limits
- suppressMessage is needed for the same reason as used for scale: multiple coord systems or scales lead to ggplot unwanted and unnecessary messages