### PR TITLE
Temporary Hotfix: Cap version for ggplot2 to below 4.0.0

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -31,6 +31,7 @@ URL: https://github.com/open-systems-pharmacology/tlf-library
 BugReports: https://github.com/open-systems-pharmacology/tlf-library/issues
 Imports: 
     ggplot2 (>= 3.3.0),
+    ggplot2 (< 4.0.0),
     R6,
     jsonlite,
     ospsuite.utils (>= 1.6.0),
@@ -42,7 +43,7 @@ Imports:
 Depends: 
     R (>= 4.1)
 Encoding: UTF-8
-RoxygenNote: 7.3.2
+RoxygenNote: 7.3.3
 Roxygen: list(markdown = TRUE)
 Suggests:
     cowplot,


### PR DESCRIPTION
Until #530 is implemented